### PR TITLE
Created easy way to use reference type name in html.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -327,7 +327,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=80
 
 # Maximum number of lines in a module.
 max-module-lines=1000
@@ -417,7 +417,6 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         no-else-return,
-        no-member
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/init.py
+++ b/src/init.py
@@ -26,6 +26,7 @@ class Reference(db.Model):  # pylint: disable=too-few-public-methods
     booktitle = db.Column(db.String)
     year = db.Column(db.Integer)
     type_id = db.Column(db.Integer, db.ForeignKey('type.id'))
+    type = db.relationship('Type')
 
     def get_reference_tag(self) -> str:
         """Generate citing tag, id + author surname + year."""

--- a/src/init.py
+++ b/src/init.py
@@ -10,7 +10,8 @@ app = Flask(__name__)
 load_dotenv()
 
 # Initialize db
-app.config['SQLALCHEMY_DATABASE_URI'] = getenv('SQLALCHEMY_DATABASE_URI', 'sqlite:///app.db')
+app.config['SQLALCHEMY_DATABASE_URI'] = getenv('SQLALCHEMY_DATABASE_URI',
+                                               'sqlite:///app.db')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
@@ -24,7 +25,7 @@ class Reference(db.Model):  # pylint: disable=too-few-public-methods
     title = db.Column(db.String)
     booktitle = db.Column(db.String)
     year = db.Column(db.Integer)
-    type_id = db.Column(db.Integer,db.ForeignKey('type.id'))
+    type_id = db.Column(db.Integer, db.ForeignKey('type.id'))
 
     def get_reference_tag(self) -> str:
         """Generate citing tag, id + author surname + year."""
@@ -46,14 +47,17 @@ class Reference(db.Model):  # pylint: disable=too-few-public-methods
         )
 
     def __eq__(self, other) -> bool:
-        """Reference object fields comparison (normal == operator would compare memory location)."""
+        """Compare reference instead of the memory address."""
         id_eq = self.id == other.id
         author_eq = self.author == other.author
         title_eq = self.title == other.title
         booktitle_eq = self.booktitle == other.booktitle
         year_eq = self.year == other.year
         type_eq = self.type_id == other.type_id
-        return id_eq and author_eq and title_eq and booktitle_eq and year_eq and type_eq
+        equality = (id_eq and author_eq and title_eq
+                    and booktitle_eq and year_eq and type_eq)
+        return equality
+
 
 class Type(db.Model):  # pylint: disable=too-few-public-methods
     """ORM database table for reference types."""


### PR DESCRIPTION
Reference type name can now be used in html templates using `reference.type.name`. Also set pylint max line length to 80 as this is what pep8 suggests, and fixed the only 2 lines that were too long.